### PR TITLE
add koji tag location support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 `pkgtreediff` compares the NVRs (name-version-release) of RPM packages in OS package trees and/or installations:
 
 - An OS tree can be referenced by an url or directory containing a tree of rpm files.
-- A file containing a list(s) of rpm NVRs can also be compared
+- A koji tag.
+- A file containing a list(s) of rpm NVRs can also be compared.
 - Commands can also be used to get installed RPMs, eg:
   - `"rpm -qa"`
   - `"ssh myhost rpm -qa"`
@@ -80,6 +81,17 @@ pkgtreediff "rpm -qa" "ssh otherhost rpm -qa"
 ```
 
 Any types of sources can be compared, together with the use of flags.
+
+### Koji
+
+Compare koji tags using the `tag`@`kojihub` syntax:
+
+```
+pkgtreediff dist-c8-updates-build@centos dist-c8_1-updates-build@centos
+```
+
+Please avoid using koji tag to compare full release as it is more efficient to
+query URL or CMD trees.
 
 ## Builds
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Any types of sources can be compared, together with the use of flags.
 
 ### Koji
 
-Compare koji tags using the `tag`@`kojihub` syntax:
+Compare koji tags using the `koji://tag@kojihub` syntax:
 
 ```
-pkgtreediff dist-c8-updates-build@centos dist-c8_1-updates-build@centos
+pkgtreediff koji://dist-c8-updates-build@centos koji://dist-c8_1-updates-build@centos
 ```
 
 Please avoid using koji tag to compare full release as it is more efficient to

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/juhp/koji-hs.git
+    tag: 84873619d266d31b4be2c1dc6eb24c0128e389dc

--- a/pkgtreediff.cabal
+++ b/pkgtreediff.cabal
@@ -32,6 +32,7 @@ executable pkgtreediff
                      , directory
                      , extra
                      , filepath
+                     , koji
                      , Glob
                      , http-client >= 0.5.0
                      , http-client-tls
@@ -43,7 +44,7 @@ executable pkgtreediff
   if impl(ghc<8.0)
       build-depends: semigroups
 
-  ghc-options:         -Wall
+  ghc-options:         -Wall -threaded
   default-language:    Haskell2010
 
 library

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -51,7 +51,7 @@ main =
     compareDirs <$> recursiveOpt <*> ignoreVR <*> ignoreArch <*> modeOpt  <*> optional patternOpt <*> timeoutOpt <*> sourceArg "1" <*> sourceArg "2"
   where
     sourceArg :: String -> Parser String
-    sourceArg pos = strArg "URL|DIR|FILE|KOJITAG|CMD" <> pos
+    sourceArg pos = strArg ("URL|DIR|FILE|KOJITAG|CMD" <> pos)
 
     modeOpt :: Parser Mode
     modeOpt =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -48,10 +48,10 @@ main :: IO ()
 main =
   simpleCmdArgs (Just version) "Package tree comparison tool"
   "pkgtreediff compares the packages in two OS trees or instances" $
-    compareDirs <$> recursiveOpt <*> ignoreVR <*> ignoreArch <*> modeOpt  <*> optional patternOpt <*> timeoutOpt <*> sourceArg <*> sourceArg
+    compareDirs <$> recursiveOpt <*> ignoreVR <*> ignoreArch <*> modeOpt  <*> optional patternOpt <*> timeoutOpt <*> sourceArg "1" <*> sourceArg "2"
   where
-    sourceArg :: Parser String
-    sourceArg = strArg "URL|TAG|DIR|FILE|CMD1"
+    sourceArg :: String -> Parser String
+    sourceArg pos = strArg "URL|DIR|FILE|KOJITAG|CMD" <> pos
 
     modeOpt :: Parser Mode
     modeOpt =

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,5 @@ resolver: lts-14.27
 
 extra-deps:
   - http-directory-0.1.8
+  - git: https://github.com/juhp/koji-hs.git
+    commit: 84873619d266d31b4be2c1dc6eb24c0128e389dc


### PR DESCRIPTION
This change enables comparing koji tag using a new syntax:
  `tag`@`kojihub`