### PR TITLE
Update the koji-hs dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/juhp/koji-hs.git
-    tag: 84873619d266d31b4be2c1dc6eb24c0128e389dc
+    tag: c28f0c40095b925c5cf38f892d0fed8926d12219

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,7 +39,7 @@ import SimpleCmd (cmd, error',
 #endif
                  )
 
-import qualified Fedora.Koji as Koji
+import qualified Distribution.Koji as Koji
 
 import Distribution.RPM.PackageTreeDiff
 import Paths_pkgtreediff (version)


### PR DESCRIPTION
This change adapts the import location for the new koji release.